### PR TITLE
Optimize empty String tests on Java 9+

### DIFF
--- a/src/main/java/jodd/csselly/selector/Match.java
+++ b/src/main/java/jodd/csselly/selector/Match.java
@@ -116,7 +116,7 @@ public enum Match {
 	PREFIX("^=") {
 		@Override
 		public boolean compare(final String attr, final String val) {
-			if (val.length() == 0) {
+			if (val.isEmpty()) {
 				return false;
 			}
 			return attr.startsWith(val);
@@ -130,7 +130,7 @@ public enum Match {
 	SUFFIX("$=") {
 		@Override
 		public boolean compare(final String attr, final String val) {
-			if (val.length() == 0) {
+			if (val.isEmpty()) {
 				return false;
 			}
 			return attr.endsWith(val);
@@ -144,7 +144,7 @@ public enum Match {
 	SUBSTRING("*=") {
 		@Override
 		public boolean compare(final String attr, final String val) {
-			if (val.length() == 0) {
+			if (val.isEmpty()) {
 				return false;
 			}
 			return attr.contains(val);

--- a/src/main/java/jodd/csselly/selector/PseudoFunctionExpression.java
+++ b/src/main/java/jodd/csselly/selector/PseudoFunctionExpression.java
@@ -48,7 +48,7 @@ public class PseudoFunctionExpression {
 			final int nndx = expression.indexOf('n');
 			if (nndx != -1) {
 				final String aVal = expression.substring(0, nndx).trim();
-				if (aVal.length() == 0) {
+				if (aVal.isEmpty()) {
 					a = 1;
 				} else {
 					if (aVal.equals(DASH)) {
@@ -58,7 +58,7 @@ public class PseudoFunctionExpression {
 					}
 				}
 				final String bVal = expression.substring(nndx + 1);
-				if (bVal.length() == 0) {
+				if (bVal.isEmpty()) {
 					b = 0;
 				} else {
 					b = parseInt(bVal);

--- a/src/main/java/jodd/jerry/Jerry.java
+++ b/src/main/java/jodd/jerry/Jerry.java
@@ -713,7 +713,7 @@ public class Jerry implements Iterable<Jerry> {
 		for (final Node node : nodes) {
 			String styleAttrValue = node.getAttribute("style");
 			final Map<String, String> styles = createPropertiesMap(styleAttrValue, ';', ':');
-			if (value.length() == 0) {
+			if (value.isEmpty()) {
 				styles.remove(propertyName);
 			} else {
 				styles.put(propertyName, value);
@@ -737,10 +737,9 @@ public class Jerry implements Iterable<Jerry> {
 			final Map<String, String> styles = createPropertiesMap(styleAttrValue, ';', ':');
 
 			for (int i = 0; i < css.length; i += 2) {
-				String propertyName = css[i];
-				propertyName = Format.fromCamelCase(propertyName, '-');
+				String propertyName = Format.fromCamelCase(css[i], '-');
 				final String value = css[i + 1];
-				if (value.length() == 0) {
+				if (value.isEmpty()) {
 					styles.remove(propertyName);
 				} else {
 					styles.put(propertyName, value);

--- a/src/test/java/jodd/lagarto/LagartoParserTest.java
+++ b/src/test/java/jodd/lagarto/LagartoParserTest.java
@@ -187,7 +187,7 @@ class LagartoParserTest {
 			public void text(final CharSequence text) {
 				String t = text.toString();
 				t = StringUtil.removeChars(t, "\r\n\t\b");
-				if (t.length() != 0) {
+				if (!t.isEmpty()) {
 					result.append("txt:[").append(t).append(']').append(NEWLINE);
 				}
 			}


### PR DESCRIPTION
Motivation:

Don't use String#length() to test emptyness. This computes the actual length, which might be non trivial with Java 9 where the underlying encoding is UTF-8 and not US-ASCII.
Use String#isEmpty() instead as it just has to check the length of the nuderlying byte array.

Modifications:

* string.length() == 0 => string.isEmpty()
* string.length() != 0 => !string.isEmpty()
* string.length() > 0 => !string.isEmpty()

Result:

More performant String emptiness test