### PR TITLE
LagartoDOMBuilderTagVisitor shouldn't log errors when error logging is disabled

### DIFF
--- a/src/main/java/jodd/lagarto/dom/LagartoDOMBuilderTagVisitor.java
+++ b/src/main/java/jodd/lagarto/dom/LagartoDOMBuilderTagVisitor.java
@@ -519,7 +519,9 @@ public class LagartoDOMBuilderTagVisitor implements TagVisitor {
 	@Override
 	public void error(final String message) {
 		rootNode.addError(message);
-		domBuilder.config.getErrorLogConsumer().accept(log, message);
+		if (domBuilder.config.errorLogEnabled) {
+			domBuilder.config.getErrorLogConsumer().accept(log, message);
+		}
 	}
 
 }


### PR DESCRIPTION
Motivation:

`errorLogEnabled` config option was introduced to disable error logging.
But `LagartoDOMBuilderTagVisitor#error` keeps on calling the ErrorLogConsumer even when errorLogEnabled is set to false.

Users can configure a noop ErrorLogConsumer instead of the default one, but still this is a workaround, not the desired behavior.

Modification:

Only call ErrorLogConsumer when error logging is enabled.

Result:

errorLogEnabled works as expected: when set to false, no error should be logged.